### PR TITLE
Fix to integrate easier with cucumber_rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ In your Gemfile
     gem "cucumber_in_groups", :git => "git://github.com/vovayartsev/cucumber_in_groups.git"
 
 
-Then add this line to your cucumber.yml
+Then update your cucumber.yml to include the line that starts with `ci`:
 
-    ci: <%= std_opts %> --tags ~@unstable  --tags ~@noci  <%=ENV["FEATURES"] %>
-
+    <% common = "--tags ~@wip --strict" %>
+    default: <%= common %>
+    ci: <%= common %> --tags ~@unstable --tags ~@noci <%= ENV["FEATURES"] %>
 
 Then in Semaphore test script, use GROUP environment variable. Group
 numbers are 1-based (e.g. 1of3, 2of3, 3of3)

--- a/lib/tasks/cucumber_in_groups.rake
+++ b/lib/tasks/cucumber_in_groups.rake
@@ -1,6 +1,7 @@
 unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
   require 'cucumber/rake/task'
+  require 'active_support/core_ext/array/grouping'
 
   namespace :cucumber do
 


### PR DESCRIPTION
Hi,

Thanks for awesome work. I tested the rake task and with a small modification, it works great.

I included `require 'active_support/core_ext/array/grouping'` in the task file because for some people Rails is not included at the moment when the task starts executing.

I also updated the README to reflect better what `common/std_opts` variable is. (`common` is name from official cucumber.yml docs.)

Let me know what you think.

Cheers,

Strika
