### PR TITLE
Removed scrict dependency on ActiveSupport version. Can't use in Rails >...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,41 +2,50 @@ PATH
   remote: .
   specs:
     cucumber_in_groups (0.0.1)
-      activesupport (~> 3.0)
+      activesupport
       cucumber (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    builder (3.2.0)
-    cucumber (1.2.3)
+    activesupport (4.1.0)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
+    cucumber (1.3.14)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.11.6)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.1)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
-    diff-lcs (1.2.2)
-    gherkin (2.11.6)
-      json (>= 1.7.6)
-    i18n (0.6.1)
-    json (1.7.7)
-    multi_json (1.7.2)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    i18n (0.6.9)
+    json (1.8.1)
+    minitest (5.3.2)
+    multi_json (1.9.2)
+    multi_test (0.1.1)
+    rake (10.2.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.0)
+    rspec-mocks (2.14.6)
+    thread_safe (0.3.3)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cucumber_in_groups!
-  rake (~> 10.0)
+  rake
   rspec (~> 2.13)

--- a/cucumber_in_groups.gemspec
+++ b/cucumber_in_groups.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
   s.files       = ["lib/cucumber_in_groups.rb"]
   s.homepage    = 'https://github.com/cloudcastle/cucumber_in_groups'
 
-  s.add_runtime_dependency "activesupport", "~> 3.0"
+  s.add_runtime_dependency "activesupport"
   s.add_runtime_dependency "cucumber", "~> 1.0"
 
-  s.add_development_dependency 'rake', "~> 10.0"
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', "~> 2.13"
 end


### PR DESCRIPTION
With Activesupport dependecy lock to 3.2 it becomes impossible to use with Rails 4
